### PR TITLE
Fixed JSON serialization issue between Annotated base class and deriv…

### DIFF
--- a/src/ModelContextProtocol.NET.Core/Models/Protocol/Shared/Content/EmbeddedResource.cs
+++ b/src/ModelContextProtocol.NET.Core/Models/Protocol/Shared/Content/EmbeddedResource.cs
@@ -1,7 +1,10 @@
-﻿namespace ModelContextProtocol.NET.Core.Models.Protocol.Shared.Content;
+﻿using System.Text.Json.Serialization;
+
+namespace ModelContextProtocol.NET.Core.Models.Protocol.Shared.Content;
 
 public record EmbeddedResource : Annotated
 {
+    [JsonIgnore]
     public string Type => "resource";
     public required ResourceContents Resource { get; init; }
 }

--- a/src/ModelContextProtocol.NET.Core/Models/Protocol/Shared/Content/ImageContent.cs
+++ b/src/ModelContextProtocol.NET.Core/Models/Protocol/Shared/Content/ImageContent.cs
@@ -1,7 +1,10 @@
-﻿namespace ModelContextProtocol.NET.Core.Models.Protocol.Shared.Content;
+﻿using System.Text.Json.Serialization;
+
+namespace ModelContextProtocol.NET.Core.Models.Protocol.Shared.Content;
 
 public record ImageContent : Annotated
 {
+    [JsonIgnore]
     public string Type => "image";
     public required string Data { get; init; }
     public required string MimeType { get; init; }

--- a/src/ModelContextProtocol.NET.Core/Models/Protocol/Shared/Content/TextContent.cs
+++ b/src/ModelContextProtocol.NET.Core/Models/Protocol/Shared/Content/TextContent.cs
@@ -1,7 +1,10 @@
+using System.Text.Json.Serialization;
+
 namespace ModelContextProtocol.NET.Core.Models.Protocol.Shared.Content;
 
 public record TextContent : Annotated
 {
+    [JsonIgnore]
     public string Type => "text";
     public required string Text { get; init; }
 


### PR DESCRIPTION
…ed classes due to 'Type' name conflict.

Experienced the following error during MCP server testing locally:

MCP error -32602: The type 'ModelContextProtocol.NET.Core.Models.Protocol.Shared.Content.TextContent' contains property 'type' that conflicts with an existing metadata property name.

Root Cause Determination:
In Annotated.cs, the base class has:
csharpCopy[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
[JsonDerivedType(typeof(TextContent), "text")]
[JsonDerivedType(typeof(ImageContent), "image")]
[JsonDerivedType(typeof(EmbeddedResource), "resource")]

The base Annotated class uses [JsonPolymorphic] with TypeDiscriminatorPropertyName = "type" to handle polymorphic serialization. Each derived content class (TextContent, ImageContent, EmbeddedResource) defined a Type property that returned a string constant. During serialization, the system tried to use both the discriminator property "type" (from the JsonPolymorphic attribute) and the actual property "Type" from the class, causing a naming conflict

Changes Made:
Added [JsonIgnore] attribute to the Type property in:

TextContent.cs
ImageContent.cs
EmbeddedResource.cs

No unit tests found in the solution, but I tested the library with these changes locally and the error has been fixed.